### PR TITLE
remove search string in url

### DIFF
--- a/src/iDisqus.js
+++ b/src/iDisqus.js
@@ -168,9 +168,9 @@
             var optsUrl = _.opts.url.replace(_.opts.site, '');
             _.opts.url = optsUrl.slice(0, 1) != '/' ? '/' + optsUrl : optsUrl;
         } else if(isEdge || isIE) {
-            _.opts.url = encodeURI(location.pathname) + encodeURI(location.search);
+            _.opts.url = encodeURI(location.pathname);// + encodeURI(location.search);
         } else {
-            _.opts.url = location.pathname + location.search;
+            _.opts.url = location.pathname;// + location.search;
         }
         _.opts.identifier = !!_.opts.identifier ? _.opts.identifier : _.opts.url;
         _.opts.link = _.opts.site + _.opts.url; 


### PR DESCRIPTION
有时在其他网站上分享链接，会自动加上搜索字符串。举个例子，在其他网站上点击`http://example.com/index.html`时会变成`http://example.com/index.html?from=timeline`，disqus默认会忽略搜索字符串，即`?from=timeline`；但iDisqus将其视为两个url，则第二个链接不会加载评论。如

![ex](https://user-images.githubusercontent.com/13688320/36482947-bbf3ab72-174f-11e8-98b6-5d55ddaf320c.PNG)

考虑到实际需求，建议去掉搜索字符串。