### PR TITLE
允许设置发件人信息

### DIFF
--- a/api/config.php
+++ b/api/config.php
@@ -55,6 +55,8 @@ define('EMOJI_PATH', 'https://assets-cdn.github.com/images/icons/emoji/unicode/'
  * SMTP_PORT      端口号
  * SMTP_USERNAME  SMTP 登录的账号，即邮箱号
  * SMTP_PASSWORD  SMTP 登录的账号，即邮箱密码
+ * SMTP_FROM      发件人的邮箱地址，可以留空
+ * SMTP_FROMNAME  发件人的名称，可以留空
  *
  */
 
@@ -63,3 +65,5 @@ define('SMTP_HOST', '');
 define('SMTP_PORT', 465);
 define('SMTP_USERNAME', '');
 define('SMTP_PASSWORD', '');
+define('SMTP_FROM', '');
+define('SMTP_FROMNAME', '');

--- a/api/sendemail.php
+++ b/api/sendemail.php
@@ -63,10 +63,12 @@ if( $parent_isanon ){
     $mail->Port       = SMTP_PORT;
     $mail->Username   = SMTP_USERNAME;
     $mail->Password   = SMTP_PASSWORD;
-    $mail->SetFrom(SMTP_USERNAME, $forum_data -> forum -> name); 
     $mail->Subject = '您在「'.$forum_data -> forum -> name.'」的评论有了新回复';
     $mail->MsgHTML($content);
     $mail->AddAddress($parent_email, $parent_name);
+    $from = !SMTP_FROM ? SMTP_USERNAME : SMTP_FROM;
+    $from_name = !SMTP_FROMNAME ? $forum_data -> forum -> name : SMTP_FROMNAME;
+    $mail->SetFrom($from, $from_name);
     if(!$mail->Send()) {
         echo "发送失败：" . $mail->ErrorInfo;
     } else {


### PR DESCRIPTION
效果如图：

![image](https://user-images.githubusercontent.com/13926390/40067007-f1d5525c-5897-11e8-99d1-566bdf53b2d8.png)

Sendgrid 的 SMTP 用户名不能设定为邮箱地址，只能手动设置发件人信息。
