### PR TITLE
修复包含链接和图片的评论被截断的问题

### DIFF
--- a/api/init.php
+++ b/api/init.php
@@ -296,15 +296,18 @@ function post_format( $post ){
     // 链接
     $post -> author -> url = !!$post -> author -> url ? $post -> author -> url : $post -> author -> profileUrl;
 
-    // 去除链接重定向
-    $urlPat = '/<a.*?href="(.*?[disq\.us][disqus\.com].*?)".*?>(.*?)<\/a>/mi';
+    $urlPat = '/<a.*?href="(.*?[disq\.us][disqus\.com][disquscdn\.com][media.giphy\.com].*?)".*?>(.*?)<\/a>/mi';
     preg_match_all($urlPat, $post -> message, $urlArr);    
     if( count($urlArr[0]) > 0 ){
         $linkArr = array();
         foreach ( $urlArr[1] as $item => $urlItem){
+            // 去除链接重定向
             if(preg_match('/^(http|https):\/\/disq\.us/i', $urlItem)){
                 parse_str(parse_url($urlItem,PHP_URL_QUERY),$out);
                 $linkArr[$item] = '<a href="'.join(':', explode(':',$out['url'],-1)).'" target="_blank" title="'.$urlArr[2][$item].'">'.$urlArr[2][$item].'</a>';
+            // 去掉图片链接
+            } elseif ( preg_match('/^(http|https):\/\/.*(disquscdn.com|media.giphy.com).*\.(jpg|gif|png)$/i', $urlItem) ){
+                $linkArr[$item] = '';
             } elseif ( strpos($urlItem, 'https://disqus.com/by/') !== false ){
                 $linkArr[$item] = '<a href="'.$urlItem.'" target="_blank" title="'.$urlArr[2][$item].'">@'.$urlArr[2][$item].'</a>';
             } else {
@@ -313,10 +316,6 @@ function post_format( $post ){
         }
         $post -> message = str_replace($urlArr[0],$linkArr,$post -> message);
     }
-
-    // 去掉图片链接
-    $imgpat = '/<a(.*?)href="(.*?(disquscdn.com|media.giphy.com).*?\.(jpg|gif|png))"(.*?)>(.*?)<\/a>/i';
-    $post -> message = preg_replace($imgpat,'',$post -> message);
 
     $imgArr = array();
     foreach ( $post -> media as $key => $image ){


### PR DESCRIPTION
如果评论包含网页链接和图片，Disqus 评论框上显示的评论会被截断。

如图，评论从链接开始的地方截断：
![](https://user-images.githubusercontent.com/13926390/42198144-ebfb00d8-7eb8-11e8-9a00-28e102310b08.png)

原生评论框能够正常显示：
![](https://user-images.githubusercontent.com/13926390/42198030-52e67210-7eb8-11e8-92c7-f0aa34390a16.png)

造成问题的相关代码：
https://github.com/fooleap/disqus-php-api/blob/4a014e1ac98ce4eb5f59dcb96b3de04927866864/api/init.php#L318

看了一些[资料](https://segmentfault.com/q/1010000002718783#a-1020000002718826)，正则表达式中第二个`.*?`会匹配网页链接与图片链接之间的所有内容，然后匹配的内容被移除掉了。

重现代码：
```php
<?php
$mesg = '<p>这是谷歌(<a href="https://www.google.com" target="_blank" title="https://www.google.com">https://www.google.com</a>)的 LOGO： <a href="https://uploads.disquscdn.com/images/af8490031b8fa919bfcd6b205e7bf8391e81c315af15c201520d3fabfa1e4bfb.jpg" target="_blank" title="https://uploads.disquscdn.c...">https://uploads.disquscdn.c...</a></p>';

$imgpat = '/<a(.*?)href="(.*?(disquscdn.com|media.giphy.com).*?\.(jpg|gif|png))"(.*?)>(.*?)<\/a>/i';
$mesg = preg_replace($imgpat, '', $mesg);
echo $mesg; // 输出：<p>这是谷歌(</p>
?>
```

修复后：
![](https://user-images.githubusercontent.com/13926390/42198149-f376fb8c-7eb8-11e8-8fbb-91dd44e7c36a.png)



