### PR TITLE
修复两个小问题

### DIFF
--- a/api/postcomment.php
+++ b/api/postcomment.php
@@ -105,6 +105,15 @@ if( isset($access_token) ){
 $data = curl_post($curl_url, $post_data);
 
 if( $data -> code == 0 ){
+
+    // 匿名用户暂存邮箱号
+    if( !isset($access_token) ){
+        $authors = $cache -> get('authors');
+        $uid = md5($authorName.email_format($authorEmail));
+        $authors -> $uid = $authorEmail;
+        $cache -> update($authors, 'authors');
+    }
+
     $rPost = post_format($data->response);
 
     $output = array(
@@ -125,15 +134,6 @@ if( $data -> code == 0 ){
     } else {
         $output['verifyCode'] = $pAuthor->isAnonymous ? $pUid : time();
         print_r(json_encode($output));
-    }
-
-
-    // 匿名用户暂存邮箱号
-    if( !isset($access_token) ){
-        $authors = $cache -> get('authors');
-        $uid = md5($authorName.email_format($authorEmail));
-        $authors -> $uid = $authorEmail;
-        $cache -> update($authors, 'authors');
     }
 
 } else {

--- a/api/postcomment.php
+++ b/api/postcomment.php
@@ -19,7 +19,7 @@ require_once('init.php');
 require_once('sendemail.php');
 
 $authorName = $_POST['name'];
-$authorEmail = $_POST['email'];
+$authorEmail = strtolower($_POST['email']);
 $authorUrl = $_POST['url'] == '' || $_POST['url'] == 'null' ? null : $_POST['url'];
 $threadId = $_POST['thread'];
 $parent = $_POST['parent'];


### PR DESCRIPTION
1. Disqus 会将匿名评论的邮箱地址转换成小写字母，如：`ABCDEF@HOTMAIL.COM -> a*****@hotmail.com`
如果邮箱地址保留大写写入到缓存，回复邮件不能发送到匿名用户。

2. 进入`post_format`函数之前暂存新的匿名用户邮箱地址，否则`post_format`函数在缓存中找不到邮箱地址，返回错误的头像地址。